### PR TITLE
メモリ使用量の観点からLazyVStackを使用するように修正

### DIFF
--- a/BasicApp/BasicApp/Views/Home/HomeView.swift
+++ b/BasicApp/BasicApp/Views/Home/HomeView.swift
@@ -10,28 +10,26 @@ import SwiftUI
 struct HomeView: View {
     @ObservedObject var viewModel: HomeViewModel
     var body: some View {
-        HomeContent(uiState: viewModel.uiState)
+        HomeViewStateless(uiState: viewModel.uiState)
     }
 }
 
-struct HomeContent: View {
+struct HomeViewStateless: View {
     let uiState: HomeUiState
     var body: some View {
         switch self.uiState {
         case .data(let data):
-            VStack(spacing: 0) {
+            VStack(spacing: 20) {
                 if !data.images.isEmpty {
                     ScrollView(.vertical, showsIndicators: true) {
-                        VStack(spacing: 16) {
+                        LazyVStack(spacing: 16) {
                             ForEach(data.images) { j in
                                 AsyncImage(url: URL(string: j.urls.regular)) { phase in
                                     if let image = phase.image {
-                                        image.resizable() // Displays the loaded image.
+                                       image.resizable() // Displays the loaded image.
                                     } else if phase.error != nil {
                                         Image(systemName: "xmark.octagon")
                                             .resizable()
-                                            .aspectRatio(contentMode: .fill)
-                                            .foregroundColor(Color.red.opacity(0.8))
                                             .frame(width: 80, height: 80 )
                                             .cornerRadius(16)
                                     } else {
@@ -40,13 +38,12 @@ struct HomeContent: View {
                                 }
                                 .frame(width: 200, height: 200 ).cornerRadius(16)
                             }
-                        }.padding(.top)
+                        }
                     }
                 } else {
                     Text("result empty...")
                 }
             }
-            .padding(.top, UIApplication.shared.windows.first!.safeAreaInsets.top)
         case .initial:
             EmptyView()
         case .loading:
@@ -60,9 +57,9 @@ struct HomeContent: View {
 struct HomeContent_Preview: PreviewProvider {
     static var previews: some View {
         Group {
-            HomeContent(uiState: HomeUiState.error("Error!!!!"))
-            HomeContent(uiState: HomeUiState.loading)
-            HomeContent(uiState: HomeUiState.initial)
+            HomeViewStateless(uiState: HomeUiState.error("Error!!!!"))
+            HomeViewStateless(uiState: HomeUiState.loading)
+            HomeViewStateless(uiState: HomeUiState.initial)
         }
     }
 }


### PR DESCRIPTION
LazyVStackについては[こちら](https://github.com/LeoAndo/ios-training/issues/99)

VStack内でListのデータを扱うと、画面外のリストアイテムインスタンスも全て生成するため、メモリ使用の無駄が生じる。
[LazyVStack](https://developer.apple.com/documentation/swiftui/lazyvstack)を使うように修正。

以下は、対応前と対応後の画面表示時のメモリ使用量。

# VStack 使用

<img width="395" alt="スクリーンショット 2022-07-04 17 44 37" src="https://user-images.githubusercontent.com/16476224/177121475-54562c70-8d79-4f08-8672-80ffdb27d66e.png">

# LazyVStack 使用

<img width="405" alt="スクリーンショット 2022-07-04 17 44 18" src="https://user-images.githubusercontent.com/16476224/177121466-922a284a-17ae-495d-be66-cae00ad21b27.png">